### PR TITLE
Fix bug caused by the change of `Buffer.beJSON()` in newest-version Node.js.

### DIFF
--- a/src/lzma_worker.js
+++ b/src/lzma_worker.js
@@ -2638,6 +2638,9 @@ var LZMA = (function () {
             } else if (s.toJSON) {
                 /// Node.js buffers have a toJSON() method that turns it into an Array.
                 chars = s.toJSON();
+                if(!(chars instanceof Array)) {
+                    chars = chars.data;
+                }
             } else {
                 for (i = 0; i < l; i += 1) {
                     chars[i] = s[i];


### PR DESCRIPTION
The bug make the function `$read_0` will not return forever.

````javascript
var b = new Buffer([1,2,3]);
//<Buffer 01 02 03>

var d = b.toJSON();
````
in old Node:
````javascript
d = [ 1, 2, 3 ]
````
in new Node:
````javascript
d = { type: 'Buffer', data: [ 1, 2, 3 ] }
````

