### PR TITLE
Error handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,11 +59,11 @@ Create the LZMA object.
     /// To compress:
     ///NOTE: mode can be 1-9 (1 is fast and pretty good; 9 is slower and probably much better).
     ///NOTE: compress() can take a string or an array of bytes. (A Node.js Buffer counts as an array of bytes.)
-    my_lzma.compress(string || byte_array, mode, on_finish(result) {}, on_progress(percent) {});
+    my_lzma.compress(string || byte_array, mode, on_finish(result, error) {}, on_progress(percent) {});
     
     /// To decompress:
     ///NOTE: The result will be returned as a string if it is printable text; otherwise, it will return an array of signed bytes.
-    my_lzma.decompress(byte_array, on_finish(result) {}, on_progress(percent) {});
+    my_lzma.decompress(byte_array, on_finish(result, error) {}, on_progress(percent) {});
 
 
 Node.js
@@ -99,9 +99,9 @@ If you'd prefer not to bother with Web Workers, you can just include <code>lzma_
 
 That will create a global <code>LZMA</code> <code>object</code> that you can use directly. Like this:
 
-    LZMA.compress(string || byte_array, mode, on_finish(result) {}, on_progress(percent) {});
+    LZMA.compress(string || byte_array, mode, on_finish(result, error) {}, on_progress(percent) {});
     
-    LZMA.decompress(byte_array, on_finish(result) {}, on_progress(percent) {});
+    LZMA.decompress(byte_array, on_finish(result, error) {}, on_progress(percent) {});
 
 Note that this <code>LZMA</code> variable is an <code>object</code>, not a <code>function</code>.
 

--- a/src/lzma.js
+++ b/src/lzma.js
@@ -8,7 +8,7 @@ if (typeof Worker === "undefined" || (typeof location !== "undefined" && locatio
     /// Is this Node.js?
     if (typeof global !== "undefined" && typeof require !== "undefined") {
         this.LZMA = function (lzma_path) {
-            return require(lzma_path || "./lzma_worker-min.js").LZMA;
+            return require(lzma_path || "./lzma_worker.js").LZMA;
         };
     /// Is this a browser?
     } else if (typeof window !== "undefined" && window.document) {

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -159,42 +159,42 @@ function decompression_test(compressed_file, correct_filename, next)
             }
             
             deco_start = get_hrtime();
-            try {
-                my_lzma.decompress(buffer, function (result)
-                {
+            my_lzma.decompress(buffer, function (result, e)
+            {
+                if (e) {
                     deco_speed = get_hrtime(deco_start);
-                    
-                    console.log("Decompressed size:", result.length + " bytes");
-                    
-                    if (typeof result === "string") {
-                        correct_result = correct_result.toString();
-                    }
-                    
-                    if (compare(correct_result, result)) {
+                    if (p.basename(correct_filename) === "error-" + e.message) {
                         display_result("Test passed", true);
+                        console.log("threw correct error: " + e.message);
                     } else {
-                        display_result("ERROR: files do not match!", false);
+                        display_result("ERROR: " + e.message, false);
                         all_tests_pass = false;
                     }
-                    
                     console.log("Decompression time:", deco_speed + " ms");
-                    
                     console.log("");
-                    next();
-                }, progress);
-            } catch (e) {
+                    return next();
+                }
+                
                 deco_speed = get_hrtime(deco_start);
-                if (p.basename(correct_filename) === "error-" + e.message) {
+                
+                console.log("Decompressed size:", result.length + " bytes");
+                
+                if (typeof result === "string") {
+                    correct_result = correct_result.toString();
+                }
+                
+                if (compare(correct_result, result)) {
                     display_result("Test passed", true);
-                    console.log("threw correct error: " + e.message);
                 } else {
-                    display_result("ERROR: " + e.message, false);
+                    display_result("ERROR: files do not match!", false);
                     all_tests_pass = false;
                 }
+                
                 console.log("Decompression time:", deco_speed + " ms");
+                
                 console.log("");
                 next();
-            }
+            }, progress);
         });
     });
 }


### PR DESCRIPTION
So, this would be my proposal for #29 – I wrapped the initialization and the contents of `do_action` in lzma_worker.js in try-catch-blocks, which catches any kind of error I can think of right now, and added a second `error` parameter to `on_finish`.

I haven’t had a lot of time to test this in the browser (with or without web worker support), so maybe take this with a little caution.