### PR TITLE
Add the possibility to terminate Web Workers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ If the decompression progress is unable to be calculated, the on_progress() func
 
 LZMA-JS will try to use Web Workers if they are available.  If the environment does not support Web Workers,
 it will just do something else, and it won't pollute the global scope.
+Each call to LZMA() will create a new Web Worker, which can be reused or terminated via my_lzma.terminateWorker().
 
 LZMA-JS was originally based on gwt-lzma, which is a port of the LZMA SDK from Java into JavaScript.
 

--- a/src/lzma.js
+++ b/src/lzma.js
@@ -62,7 +62,8 @@ if (typeof Worker === "undefined" || (typeof location !== "undefined" && locatio
                                 fake_lzma.decompress(byte_arr, on_finish, on_progress);
                             }, 50);
                         }
-                    }
+                    },
+                    terminateWorker: function() {}
                 };
                 
                 return fake_lzma;
@@ -136,6 +137,10 @@ if (typeof Worker === "undefined" || (typeof location !== "undefined" && locatio
                 },
                 decompress: function decompress(byte_arr, on_finish, on_progress) {
                     send_to_worker(action_decompress, byte_arr, false, on_finish, on_progress);
+                },
+                terminateWorker: function terminateWorker() {
+                    lzma_worker.terminate();
+                    lzma_worker = null;
                 }
             };
         }());

--- a/src/lzma_worker.js
+++ b/src/lzma_worker.js
@@ -2628,7 +2628,8 @@ var LZMA = (function () {
     return {
         /** xs */
         compress:   compress,
-        decompress: decompress
+        decompress: decompress,
+        terminateWorker: function() {}
         /** xe */
         /// co:compress:   compress
         /// do:decompress: decompress


### PR DESCRIPTION
This adds a `.terminateWorker` method to the `lzma` object, which terminates the associated web worker (if web workers are available and have been used).

A possible (and my intended) use case is to use multiple `LZMA()` instances in parallel in order to increase overall compression speed; Since Web Workers, however, don’t seem to abide by the normal garbage collection rules, this requires some way of stopping them once their work is done.