### PR TITLE
Allow direct Uint8Array output

### DIFF
--- a/src/lzma.js
+++ b/src/lzma.js
@@ -50,14 +50,14 @@ if (typeof Worker === "undefined" || (typeof location !== "undefined" && locatio
                             }, 50);
                         }
                     },
-                    decompress: function decompress(byte_arr, on_finish, on_progress) {
+                    decompress: function decompress(byte_arr, is_utf8, on_finish, on_progress) {
                         if (global_var.LZMA_WORKER) {
-                            global_var.LZMA_WORKER.decompress(byte_arr, on_finish, on_progress);
+                            global_var.LZMA_WORKER.decompress(byte_arr, is_utf8, on_finish, on_progress);
                         } else {
                             /// Wait
                             setTimeout(function ()
                             {
-                                fake_lzma.decompress(byte_arr, on_finish, on_progress);
+                                fake_lzma.decompress(byte_arr, is_utf8, on_finish, on_progress);
                             }, 50);
                         }
                     },
@@ -141,8 +141,8 @@ if (typeof Worker === "undefined" || (typeof location !== "undefined" && locatio
                 compress: function compress(mixed, mode, on_finish, on_progress) {
                     send_to_worker(action_compress, mixed, mode, on_finish, on_progress);
                 },
-                decompress: function decompress(byte_arr, on_finish, on_progress) {
-                    send_to_worker(action_decompress, byte_arr, false, on_finish, on_progress);
+                decompress: function decompress(byte_arr, is_utf8, on_finish, on_progress) {
+                    send_to_worker(action_decompress, byte_arr, is_utf8, on_finish, on_progress);
                 },
                 worker: function worker() {
                     return lzma_worker;


### PR DESCRIPTION
Add a `is_utf8` parameter to `decompress()`, which defaults to `true` (i.e. current behaviour). When set to `false`, makes the decompressor always return a raw `Uint8Array` instance.

@nmrugg If you think this is a good idea, I’ll be happy to write tests for this + a bit for the readme, but I’ll wait for your thoughts on this before I get started on that :smile: